### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/projects/ai-trip-planner/mainnew.py
+++ b/projects/ai-trip-planner/mainnew.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 import datetime
 from dotenv import load_dotenv
 from pydantic import BaseModel
+import logging
 load_dotenv()
 
 
@@ -47,4 +48,5 @@ async def query_travel_agent(query:QueryRequest):
         
         return {"answer": final_output}
     except Exception as e:
-        return JSONResponse(status_code=500, content={"error": str(e)})
+        logging.exception("Exception occurred in /query endpoint")
+        return JSONResponse(status_code=500, content={"error": "An internal error has occurred."})


### PR DESCRIPTION
Potential fix for [https://github.com/bibhu2020/genai/security/code-scanning/5](https://github.com/bibhu2020/genai/security/code-scanning/5)

To fix this problem, the code should avoid exposing the raw exception message to the client. Instead, it should log the exception details on the server for debugging purposes and return a generic error message to the client. This can be achieved by using Python's `logging` module to log the exception (including the stack trace), and then returning a generic error message such as `"An internal error has occurred."` in the JSON response. The changes should be made in the `except` block of the `/query` endpoint in `projects/ai-trip-planner/mainnew.py`. Additionally, an import for the `logging` module should be added at the top of the file if it is not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
