### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/apply-acl.yml
+++ b/.github/workflows/apply-acl.yml
@@ -1,4 +1,6 @@
 name: Apply ACL
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bibhu2020/genai/security/code-scanning/1](https://github.com/bibhu2020/genai/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. The safest starting point is to set `contents: read` at the workflow or job level, and only add additional permissions if the workflow requires them. In this case, since the workflow appears to only check out code and run a Python script (with a token provided via secrets), `contents: read` is likely sufficient. The change should be made near the top of the file, after the `name` field and before `on:` (for workflow-level), or under the job (for job-level). The best practice is to set it at the workflow level unless jobs have different requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
